### PR TITLE
chore(css): fondo #f6f6f6 en bloques del sidebar de filtros

### DIFF
--- a/assets/component-filter.css
+++ b/assets/component-filter.css
@@ -546,6 +546,7 @@ body:not(.firefox) .facets__price--slide::before {
     margin-bottom: 20px;
     padding: 10px;
     border-radius: 10px;
+    background: #f6f6f6;
 }
 
 .page-sidebar.page-sidebar--vertical+.page-content .toolbar-wrapper .results-count{


### PR DESCRIPTION
Cambio puntual de estilo en .

- Selector: 
- Ajuste: 
- Objetivo: dar un fondo gris claro a los bloques del sidebar de filtros para mejorar legibilidad y separación visual.

Sin cambios de lógica, solo UI.