### PR TITLE
feat(pdp): financing snippet for PDP installments

### DIFF
--- a/assets/product-financing.css
+++ b/assets/product-financing.css
@@ -1,0 +1,123 @@
+/* product-financing.css */
+.product-financing { 
+  margin: 16px 0 24px; 
+}
+
+.product-financing .financing__box {
+  border: 1px solid var(--color-border, rgba(120,129,136,.2));
+  border-radius: 12px;
+  background: var(--bg-white, #fff);
+  overflow: hidden;
+}
+
+.product-financing .financing__summary {
+  display: flex;
+  align-items: center;
+  gap: .6rem;
+  padding: 1.2rem 1.6rem;
+  font-weight: 700;
+  color: var(--color-text, #222);
+  cursor: pointer;
+  list-style: none;
+}
+
+.product-financing .financing__summary::-webkit-details-marker { display: none; }
+
+.product-financing .financing__content {
+  padding: 1.2rem 1.6rem 1.6rem;
+}
+
+/* Installment row */
+.financing__installment {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.2rem;
+  border: 1px solid var(--color-border, rgba(120,129,136,.2));
+  border-radius: 12px;
+  background: var(--color-background, #f8f8f8);
+}
+
+.financing__amount {
+  font-size: clamp(2.2rem, 2vw + 1rem, 3.2rem);
+  font-weight: 800;
+  line-height: 1.1;
+  color: var(--color-base-accent-1, #1a73e8);
+}
+
+.financing__per {
+  display: flex;
+  align-items: center;
+  gap: .6rem;
+}
+
+.financing__per-text { font-weight: 600; }
+
+.financing__months {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding: .8rem 1rem;
+  border-radius: 10px;
+  border: 1px solid var(--color-border, rgba(120,129,136,.3));
+  background: var(--bg-white, #fff);
+  font-weight: 700;
+  min-width: 140px;
+}
+
+/* Methods */
+.financing__methods { margin-top: 1.4rem; }
+.financing__methods-title { font-weight: 700; margin-bottom: .8rem; }
+
+.financing__logos {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: .8rem;
+}
+
+@media (max-width: 1024px) {
+  .financing__logos { grid-template-columns: repeat(3, 1fr); }
+}
+
+@media (max-width: 640px) {
+  .financing__logos { grid-template-columns: repeat(2, 1fr); }
+}
+
+.financing__logo-link, .financing__logo {
+  display: block;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--color-border, rgba(120,129,136,.2));
+  background: var(--bg-white, #fff);
+  text-align: center;
+  transition: transform .2s ease, box-shadow .2s ease;
+}
+
+.financing__logo-link:hover .financing__logo, .financing__logo:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 18px rgba(0,0,0,.06);
+}
+
+.financing__logo img { 
+  max-height: 28px; 
+  width: auto; 
+  display: block; 
+  margin: 0 auto; 
+}
+
+.financing__logo-fallback {
+  display: block;
+  text-align: center;
+  font-weight: 600;
+  font-size: 1.4rem;
+}
+
+/* Notes */
+.financing__notes { 
+  margin-top: 1.2rem; 
+  font-size: 1.3rem; 
+  color: var(--color-text, #222); 
+}
+.financing__notes ul { padding-left: 1.2rem; margin: 0; }
+.financing__notes li { margin: .4rem 0; }

--- a/snippets/product-financing.liquid
+++ b/snippets/product-financing.liquid
@@ -1,0 +1,219 @@
+{% comment %}
+  Snippet: product-financing
+  Uso sugerido desde un bloque "Liquid personalizado" en la PDP:
+
+  {% render 'product-financing',
+    enabled: true,
+    title: 'Llévalo hoy con 0% de interés',
+    months: '3,6,12,24',
+    methods: 'Davivienda|davivienda.svg|https://tudominio.com/financia,BBVA|bbva.svg|https://wa.me/XXXXXXXXXXX',
+    notes: 'Hasta 24 meses con Davivienda, Banco de Occidente, Banco Popular, BBVA y RappiPay.||Con Bancolombia: hasta 24 meses en iPhone y Mac, y hasta 12 meses en los demás productos desde $800.000.'
+  %}
+
+  Parámetros:
+  - enabled: true/false para mostrar u ocultar el módulo.
+  - title: título del acordeón.
+  - months: string separado por comas con los plazos (por ej. '3,6,12,24').
+  - methods: lista separada por comas, cada método como "Nombre|archivo_logo.svg|URL". El logo debe existir en assets/.
+  - notes: lista de notas separadas por "||" para mostrar viñetas.
+
+  Notas:
+  - El módulo sólo es visual. No afecta el checkout.
+  - Calcula la cuota dividiendo el precio de la variante por el número de meses (0% interés).
+  - Se actualiza al cambiar de variante.
+{% endcomment %}
+
+{% liquid
+  assign enabled_str = enabled | default: 'true' | downcase
+%}
+
+{% if enabled_str == 'false' or enabled_str == '0' %}
+  <!-- Oculto por configuración -->
+{% else %}
+  {{ 'product-financing.css' | asset_url | stylesheet_tag }}
+
+  {% liquid
+    assign months_str = months | default: '3,6,12,24'
+    assign months_arr = months_str | split: ','
+
+    assign methods_str = methods | default: ''
+    assign methods_arr = methods_str | split: ','
+
+    assign notes_str = notes | default: ''
+    assign notes_arr = notes_str | split: '||'
+
+    assign heading = title | default: 'Llévalo hoy con 0% de interés'
+
+    assign dom_id = 'financing-' | append: product.id | default: 'financing-generic'
+
+    assign selected_variant = product.selected_or_first_available_variant
+    if selected_variant == nil and product.variants.size > 0
+      assign selected_variant = product.variants.first
+    endif
+
+    assign fallback_price_cents = 0
+    if selected_variant
+      assign fallback_price_cents = selected_variant.price
+    elsif product
+      assign fallback_price_cents = product.price
+    endif
+  %}
+
+  <div id="{{ dom_id }}" class="product-financing" data-money-format="{{ shop.money_format | escape }}" data-currency="{{ shop.currency }}" data-locale="{{ request.locale.iso_code }}" data-fallback-price="{{ fallback_price_cents }}">
+    <details class="financing__box" open>
+      <summary class="financing__summary">
+        <span class="financing__summary-title">{{ heading }}</span>
+      </summary>
+      <div class="financing__content">
+        <div class="financing__installment">
+          <div class="financing__amount" data-financing-amount>—</div>
+          <div class="financing__per">
+            <span class="financing__per-text">al mes por</span>
+            <select class="financing__months" data-financing-months aria-label="Selecciona meses">
+              {% for m in months_arr %}
+                {% assign m_trim = m | strip %}
+                <option value="{{ m_trim }}" {% if forloop.last %}selected{% endif %}>{{ m_trim }} meses</option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+
+        {% if methods_str != '' %}
+          <div class="financing__methods">
+            <div class="financing__methods-title">Aprovecha con tu tarjeta favorita:</div>
+            <ul class="financing__logos" role="list">
+              {% for method in methods_arr %}
+                {% assign item = method | strip %}
+                {% assign parts = item | split: '|' %}
+                {% assign method_name = parts[0] | strip %}
+                {% assign method_logo = parts[1] | default: '' | strip %}
+                {% assign method_url  = parts[2] | default: '' | strip %}
+                <li class="financing__logo-item">
+                  {% if method_url != '' %}<a href="{{ method_url }}" class="financing__logo-link" target="_blank" rel="noopener noreferrer">{% endif %}
+                    <div class="financing__logo">
+                      {% if method_logo != '' %}
+                        {% if method_logo contains 'http' or method_logo contains '//' %}
+                          <img src="{{ method_logo }}" alt="{{ method_name }}" loading="lazy" />
+                        {% else %}
+                          <img src="{{ method_logo | asset_url }}" alt="{{ method_name }}" loading="lazy" onerror="this.onerror=null;this.src='{{ method_logo | file_url }}';" />
+                        {% endif %}
+                      {% else %}
+                        <span class="financing__logo-fallback">{{ method_name }}</span>
+                      {% endif %}
+                    </div>
+                  {% if method_url != '' %}</a>{% endif %}
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+
+        {% if notes_str != '' %}
+          <div class="financing__notes">
+            <ul>
+              {% for note in notes_arr %}
+                {% assign note_text = note | strip %}
+                {% if note_text != '' %}<li>{{ note_text }}</li>{% endif %}
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+      </div>
+    </details>
+
+    <script type="application/json" data-financing-variants>
+      [
+      {% if product and product.variants.size > 0 %}
+        {% for v in product.variants %}
+          {"id": {{ v.id }}, "price": {{ v.price }} }{% unless forloop.last %},{% endunless %}
+        {% endfor %}
+      {% endif %}
+      ]
+    </script>
+
+    <script>
+    (function(){
+      var root = document.getElementById('{{ dom_id }}');
+      if(!root) return;
+      var moneyFormat = root.getAttribute('data-money-format') || "${{amount}}";
+      var currency = root.getAttribute('data-currency') || 'USD';
+      var locale = root.getAttribute('data-locale') || 'es';
+      var fallbackPrice = parseInt(root.getAttribute('data-fallback-price') || '0', 10) || 0;
+
+      var amountEl = root.querySelector('[data-financing-amount]');
+      var monthsSelect = root.querySelector('[data-financing-months]');
+
+      var variantsJSON = [];
+      try {
+        var jsonEl = root.querySelector('[data-financing-variants]');
+        if (jsonEl) variantsJSON = JSON.parse(jsonEl.textContent || '[]');
+      } catch(e) { variantsJSON = []; }
+
+      var priceById = {};
+      variantsJSON.forEach(function(v){ priceById[v.id] = v.price; });
+
+      function formatMoney(cents){
+        if (window.Shopify && typeof Shopify.formatMoney === 'function') {
+          return Shopify.formatMoney(cents, moneyFormat);
+        }
+        try {
+          return new Intl.NumberFormat(locale, { style: 'currency', currency: currency, maximumFractionDigits: 0 }).format(cents/100);
+        } catch(e) {
+          return (cents/100).toFixed(0);
+        }
+      }
+
+      function getCurrentVariantId(){
+        var input = document.querySelector('form[action="/cart/add"] [name="id"]');
+        if (!input) input = document.querySelector('[name="id"][form]');
+        if (!input) input = document.querySelector('select[name="id"], input[name="id"][type="hidden"], input[name="id"][type="radio"]:checked');
+        var val = input ? parseInt(input.value, 10) : NaN;
+        if (!isNaN(val)) return val;
+        // fallback to any key in map
+        var keys = Object.keys(priceById);
+        if (keys.length) return parseInt(keys[0], 10);
+        return null;
+      }
+
+      function currentPriceCents(){
+        var vid = getCurrentVariantId();
+        if (vid && priceById[vid] != null) return parseInt(priceById[vid], 10) || 0;
+        return fallbackPrice;
+      }
+
+      function updateAmount(){
+        var m = parseInt(monthsSelect && monthsSelect.value || '1', 10) || 1;
+        var price = currentPriceCents();
+        if (!price || price <= 0) { amountEl.textContent = '—'; return; }
+        var perMonth = Math.round(price / m);
+        amountEl.textContent = formatMoney(perMonth);
+      }
+
+      // React to month selection changes
+      if (monthsSelect) monthsSelect.addEventListener('change', updateAmount);
+
+      // React to theme-specific variant change events
+      document.addEventListener('variant:change', function(e){
+        if (e && e.detail && e.detail.variant) {
+          var v = e.detail.variant;
+          if (v && v.id && typeof v.price === 'number') priceById[v.id] = v.price;
+          updateAmount();
+        }
+      });
+      document.addEventListener('product:variant-change', function(){ updateAmount(); });
+
+      // React to native changes on variant selector inputs
+      document.addEventListener('change', function(ev){
+        var t = ev.target;
+        if (!t) return;
+        if (t.name === 'id' || t.closest('variant-radios') || t.closest('variant-selects')) {
+          updateAmount();
+        }
+      });
+
+      // Initial calculation
+      updateAmount();
+    })();
+    </script>
+  </div>
+{% endif %}


### PR DESCRIPTION
## Resumen
Agregar módulo visual de financiación para la PDP que calcula la cuota mensual (0% interés) a partir del precio de la variante y permite configurar plazos, métodos (logos + links) y notas.

## Cambios
- Nuevo snippet: `snippets/product-financing.liquid`
  - Calcula cuotas en base a `variant.price / meses` y formatea con `Shopify.formatMoney` o `Intl.NumberFormat`.
  - Se actualiza al cambiar de variante (escucha `variant:change`, `product:variant-change` y cambios nativos en inputs `name="id"`).
  - Parámetros: `enabled`, `title`, `months`, `methods`, `notes`.
  - Soporte de logos desde `assets/`, `file_url` o URL remota.
- Nuevo CSS: `assets/product-financing.css` (estilos acordeón, tarjeta de cuota, grilla de logos y notas).

## Uso (bloque "Liquid personalizado")
En la plantilla del producto, agregar un bloque "Liquid personalizado" con:

```liquid
{% render 'product-financing',
  enabled: true,
  title: 'Llévalo hoy con 0% de interés',
  months: '3,6,12,24',
  methods: 'Davivienda|davivienda.svg|https://tudominio.com/financia,BBVA|https://cdn.tudominio.com/bbva.svg|https://wa.me/XXXXXXXXXXX',
  notes: 'Hasta 24 meses con Davivienda, Banco de Occidente, Banco Popular, BBVA y RappiPay.||Con Bancolombia: hasta 24 meses en iPhone y Mac, y hasta 12 meses en los demás productos desde $800.000.'
%}
```

- `months`: lista separada por comas (puede ser 2,4,8, etc.).
- `methods`: `Nombre|archivo_logo.svg|URL` (si el logo no está en `assets/`, usar URL completa o se intentará `file_url`).
- `notes`: separadas por `||`.

## Notas
- Módulo informativo: no afecta el checkout.
- Redondeo simple al entero más cercano.
- Estilos usan variables del tema (`--color-text`, `--color-background`, etc.).

## Pruebas manuales
- Cambiar variante y validar actualización de la cuota.
- Cambiar meses y validar cálculo.
- Probar con y sin logos (debe mostrar fallback con el nombre).

## Checklist
- [x] Snippet y CSS creados.
- [x] Cálculo y formateo de moneda.
- [x] Soporte de URLs remotas y `file_url` para logos.
- [x] Documentación de uso en el comentario del snippet y en esta PR.
