### PR TITLE
feat(pdp): add media_custom_liquid block below gallery across all layouts

### DIFF
--- a/sections/main-product-full-width-2.liquid
+++ b/sections/main-product-full-width-2.liquid
@@ -3187,6 +3187,42 @@
             ]
         },
         {
+            "type": "media_custom_liquid",
+            "name": "Custom liquid (below gallery)",
+            "settings": [
+                {
+                    "type": "liquid",
+                    "id": "custom_liquid",
+                    "label": "t:sections.custom-liquid.settings.custom_liquid.label",
+                    "info": "t:sections.custom-liquid.settings.custom_liquid.info"
+                },
+                {
+                    "type": "header",
+                    "content": "t:sections.main-product.settings.general.block_spacing"
+                },
+                {
+                    "type": "range",
+                    "id": "spacing_top",
+                    "label": "t:settings_schema.typography.settings.type_button_font.padding_top",
+                    "min": 0,
+                    "max": 100,
+                    "step": 1,
+                    "unit": "t:sections.layout.mg_desktop.unit",
+                    "default": 0
+                },
+                {
+                    "type": "range",
+                    "id": "spacing_bottom",
+                    "label": "t:settings_schema.typography.settings.type_button_font.padding_bottom",
+                    "min": 0,
+                    "max": 100,
+                    "step": 1,
+                    "unit": "t:sections.layout.mg_desktop.unit",
+                    "default": 0
+                }
+            ]
+        },
+        {
             "type": "complementary_products",
             "name": "t:sections.main-product.settings.complementary.label",
             "settings": [

--- a/sections/main-product-full-width.liquid
+++ b/sections/main-product-full-width.liquid
@@ -3191,6 +3191,42 @@
             ]
         },
         {
+            "type": "media_custom_liquid",
+            "name": "Custom liquid (below gallery)",
+            "settings": [
+                {
+                    "type": "liquid",
+                    "id": "custom_liquid",
+                    "label": "t:sections.custom-liquid.settings.custom_liquid.label",
+                    "info": "t:sections.custom-liquid.settings.custom_liquid.info"
+                },
+                {
+                    "type": "header",
+                    "content": "t:sections.main-product.settings.general.block_spacing"
+                },
+                {
+                    "type": "range",
+                    "id": "spacing_top",
+                    "label": "t:settings_schema.typography.settings.type_button_font.padding_top",
+                    "min": 0,
+                    "max": 100,
+                    "step": 1,
+                    "unit": "t:sections.layout.mg_desktop.unit",
+                    "default": 0
+                },
+                {
+                    "type": "range",
+                    "id": "spacing_bottom",
+                    "label": "t:settings_schema.typography.settings.type_button_font.padding_bottom",
+                    "min": 0,
+                    "max": 100,
+                    "step": 1,
+                    "unit": "t:sections.layout.mg_desktop.unit",
+                    "default": 0
+                }
+            ]
+        },
+        {
             "type": "complementary_products",
             "name": "t:sections.main-product.settings.complementary.label",
             "settings": [

--- a/sections/main-product-gallery.liquid
+++ b/sections/main-product-gallery.liquid
@@ -3191,6 +3191,42 @@
             ]
         },
         {
+            "type": "media_custom_liquid",
+            "name": "Custom liquid (below gallery)",
+            "settings": [
+                {
+                    "type": "liquid",
+                    "id": "custom_liquid",
+                    "label": "t:sections.custom-liquid.settings.custom_liquid.label",
+                    "info": "t:sections.custom-liquid.settings.custom_liquid.info"
+                },
+                {
+                    "type": "header",
+                    "content": "t:sections.main-product.settings.general.block_spacing"
+                },
+                {
+                    "type": "range",
+                    "id": "spacing_top",
+                    "label": "t:settings_schema.typography.settings.type_button_font.padding_top",
+                    "min": 0,
+                    "max": 100,
+                    "step": 1,
+                    "unit": "t:sections.layout.mg_desktop.unit",
+                    "default": 0
+                },
+                {
+                    "type": "range",
+                    "id": "spacing_bottom",
+                    "label": "t:settings_schema.typography.settings.type_button_font.padding_bottom",
+                    "min": 0,
+                    "max": 100,
+                    "step": 1,
+                    "unit": "t:sections.layout.mg_desktop.unit",
+                    "default": 0
+                }
+            ]
+        },
+        {
             "type": "complementary_products",
             "name": "t:sections.main-product.settings.complementary.label",
             "settings": [

--- a/sections/main-product-horizontal-tabs-no-sidebar.liquid
+++ b/sections/main-product-horizontal-tabs-no-sidebar.liquid
@@ -3166,6 +3166,42 @@
             ]
         },
         {
+            "type": "media_custom_liquid",
+            "name": "Custom liquid (below gallery)",
+            "settings": [
+                {
+                    "type": "liquid",
+                    "id": "custom_liquid",
+                    "label": "t:sections.custom-liquid.settings.custom_liquid.label",
+                    "info": "t:sections.custom-liquid.settings.custom_liquid.info"
+                },
+                {
+                    "type": "header",
+                    "content": "t:sections.main-product.settings.general.block_spacing"
+                },
+                {
+                    "type": "range",
+                    "id": "spacing_top",
+                    "label": "t:settings_schema.typography.settings.type_button_font.padding_top",
+                    "min": 0,
+                    "max": 100,
+                    "step": 1,
+                    "unit": "t:sections.layout.mg_desktop.unit",
+                    "default": 0
+                },
+                {
+                    "type": "range",
+                    "id": "spacing_bottom",
+                    "label": "t:settings_schema.typography.settings.type_button_font.padding_bottom",
+                    "min": 0,
+                    "max": 100,
+                    "step": 1,
+                    "unit": "t:sections.layout.mg_desktop.unit",
+                    "default": 0
+                }
+            ]
+        },
+        {
             "type": "complementary_products",
             "name": "t:sections.main-product.settings.complementary.label",
             "settings": [

--- a/sections/main-product-left-right-sidebar.liquid
+++ b/sections/main-product-left-right-sidebar.liquid
@@ -3185,6 +3185,42 @@
             ]
         },
         {
+            "type": "media_custom_liquid",
+            "name": "Custom liquid (below gallery)",
+            "settings": [
+                {
+                    "type": "liquid",
+                    "id": "custom_liquid",
+                    "label": "t:sections.custom-liquid.settings.custom_liquid.label",
+                    "info": "t:sections.custom-liquid.settings.custom_liquid.info"
+                },
+                {
+                    "type": "header",
+                    "content": "t:sections.main-product.settings.general.block_spacing"
+                },
+                {
+                    "type": "range",
+                    "id": "spacing_top",
+                    "label": "t:settings_schema.typography.settings.type_button_font.padding_top",
+                    "min": 0,
+                    "max": 100,
+                    "step": 1,
+                    "unit": "t:sections.layout.mg_desktop.unit",
+                    "default": 0
+                },
+                {
+                    "type": "range",
+                    "id": "spacing_bottom",
+                    "label": "t:settings_schema.typography.settings.type_button_font.padding_bottom",
+                    "min": 0,
+                    "max": 100,
+                    "step": 1,
+                    "unit": "t:sections.layout.mg_desktop.unit",
+                    "default": 0
+                }
+            ]
+        },
+        {
             "type": "complementary_products",
             "name": "t:sections.main-product.settings.complementary.label",
             "settings": [

--- a/sections/main-product-left-thumbs.liquid
+++ b/sections/main-product-left-thumbs.liquid
@@ -3185,6 +3185,42 @@
             ]
         },
         {
+            "type": "media_custom_liquid",
+            "name": "Custom liquid (below gallery)",
+            "settings": [
+                {
+                    "type": "liquid",
+                    "id": "custom_liquid",
+                    "label": "t:sections.custom-liquid.settings.custom_liquid.label",
+                    "info": "t:sections.custom-liquid.settings.custom_liquid.info"
+                },
+                {
+                    "type": "header",
+                    "content": "t:sections.main-product.settings.general.block_spacing"
+                },
+                {
+                    "type": "range",
+                    "id": "spacing_top",
+                    "label": "t:settings_schema.typography.settings.type_button_font.padding_top",
+                    "min": 0,
+                    "max": 100,
+                    "step": 1,
+                    "unit": "t:sections.layout.mg_desktop.unit",
+                    "default": 0
+                },
+                {
+                    "type": "range",
+                    "id": "spacing_bottom",
+                    "label": "t:settings_schema.typography.settings.type_button_font.padding_bottom",
+                    "min": 0,
+                    "max": 100,
+                    "step": 1,
+                    "unit": "t:sections.layout.mg_desktop.unit",
+                    "default": 0
+                }
+            ]
+        },
+        {
             "type": "complementary_products",
             "name": "t:sections.main-product.settings.complementary.label",
             "settings": [

--- a/sections/main-product-right-thumbs.liquid
+++ b/sections/main-product-right-thumbs.liquid
@@ -3185,6 +3185,42 @@
             ]
         },
         {
+            "type": "media_custom_liquid",
+            "name": "Custom liquid (below gallery)",
+            "settings": [
+                {
+                    "type": "liquid",
+                    "id": "custom_liquid",
+                    "label": "t:sections.custom-liquid.settings.custom_liquid.label",
+                    "info": "t:sections.custom-liquid.settings.custom_liquid.info"
+                },
+                {
+                    "type": "header",
+                    "content": "t:sections.main-product.settings.general.block_spacing"
+                },
+                {
+                    "type": "range",
+                    "id": "spacing_top",
+                    "label": "t:settings_schema.typography.settings.type_button_font.padding_top",
+                    "min": 0,
+                    "max": 100,
+                    "step": 1,
+                    "unit": "t:sections.layout.mg_desktop.unit",
+                    "default": 0
+                },
+                {
+                    "type": "range",
+                    "id": "spacing_bottom",
+                    "label": "t:settings_schema.typography.settings.type_button_font.padding_bottom",
+                    "min": 0,
+                    "max": 100,
+                    "step": 1,
+                    "unit": "t:sections.layout.mg_desktop.unit",
+                    "default": 0
+                }
+            ]
+        },
+        {
             "type": "complementary_products",
             "name": "t:sections.main-product.settings.complementary.label",
             "settings": [

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -3201,6 +3201,42 @@
             ]
         },
         {
+            "type": "media_custom_liquid",
+            "name": "Custom liquid (below gallery)",
+            "settings": [
+                {
+                    "type": "liquid",
+                    "id": "custom_liquid",
+                    "label": "t:sections.custom-liquid.settings.custom_liquid.label",
+                    "info": "t:sections.custom-liquid.settings.custom_liquid.info"
+                },
+                {
+                    "type": "header",
+                    "content": "t:sections.main-product.settings.general.block_spacing"
+                },
+                {
+                    "type": "range",
+                    "id": "spacing_top",
+                    "label": "t:settings_schema.typography.settings.type_button_font.padding_top",
+                    "min": 0,
+                    "max": 100,
+                    "step": 1,
+                    "unit": "t:sections.layout.mg_desktop.unit",
+                    "default": 0
+                },
+                {
+                    "type": "range",
+                    "id": "spacing_bottom",
+                    "label": "t:settings_schema.typography.settings.type_button_font.padding_bottom",
+                    "min": 0,
+                    "max": 100,
+                    "step": 1,
+                    "unit": "t:sections.layout.mg_desktop.unit",
+                    "default": 0
+                }
+            ]
+        },
+        {
             "type": "complementary_products",
             "name": "t:sections.main-product.settings.complementary.label",
             "settings": [

--- a/snippets/product-page-full-width-2.liquid
+++ b/snippets/product-page-full-width-2.liquid
@@ -771,6 +771,20 @@
                                     </div>
                                 </div>
                             {%- endif -%}
+                            {%- comment -%} Below gallery custom content blocks {%- endcomment -%}
+                            {%- for block in section.blocks -%}
+                              {%- if block.type == 'media_custom_liquid' -%}
+                                {%- liquid
+                                  assign spacing_top = block.settings.spacing_top
+                                  assign spacing_bottom = block.settings.spacing_bottom
+                                -%}
+                                <div class="productView-moreItem productView-moreItem--media{% if settings.banner_animation == 'effect_fade_up' %} scroll-trigger animate--slide-in{% endif %}"
+                                  style="--spacing-top: {{ spacing_top | append: 'px' }}; --spacing-bottom: {{ spacing_bottom | append: 'px' }}"
+                                >
+                                  {{ block.settings.custom_liquid }}
+                                </div>
+                              {%- endif -%}
+                            {%- endfor -%}
                         </div>
                     </div>
                     <div class="halo-productView-right productView-details clearfix">

--- a/snippets/product-page-full-width.liquid
+++ b/snippets/product-page-full-width.liquid
@@ -772,6 +772,20 @@
                                     </div>
                                 </div>
                             {%- endif -%}
+                            {%- comment -%} Below gallery custom content blocks {%- endcomment -%}
+                            {%- for block in section.blocks -%}
+                              {%- if block.type == 'media_custom_liquid' -%}
+                                {%- liquid
+                                  assign spacing_top = block.settings.spacing_top
+                                  assign spacing_bottom = block.settings.spacing_bottom
+                                -%}
+                                <div class="productView-moreItem productView-moreItem--media{% if settings.banner_animation == 'effect_fade_up' %} scroll-trigger animate--slide-in{% endif %}"
+                                  style="--spacing-top: {{ spacing_top | append: 'px' }}; --spacing-bottom: {{ spacing_bottom | append: 'px' }}"
+                                >
+                                  {{ block.settings.custom_liquid }}
+                                </div>
+                              {%- endif -%}
+                            {%- endfor -%}
                         </div>
                     </div>
                     <div class="halo-productView-right productView-details clearfix">

--- a/snippets/product-page-gallery.liquid
+++ b/snippets/product-page-gallery.liquid
@@ -759,6 +759,20 @@
                                     </div>
                                 </div>
                             {%- endif -%}
+                            {%- comment -%} Below gallery custom content blocks {%- endcomment -%}
+                            {%- for block in section.blocks -%}
+                              {%- if block.type == 'media_custom_liquid' -%}
+                                {%- liquid
+                                  assign spacing_top = block.settings.spacing_top
+                                  assign spacing_bottom = block.settings.spacing_bottom
+                                -%}
+                                <div class="productView-moreItem productView-moreItem--media{% if settings.banner_animation == 'effect_fade_up' %} scroll-trigger animate--slide-in{% endif %}"
+                                  style="--spacing-top: {{ spacing_top | append: 'px' }}; --spacing-bottom: {{ spacing_bottom | append: 'px' }}"
+                                >
+                                  {{ block.settings.custom_liquid }}
+                                </div>
+                              {%- endif -%}
+                            {%- endfor -%}
                         </div>
                     </div>
                     <div class="halo-productView-right productView-details clearfix">

--- a/snippets/product-page-horizontal-tabs-no-sidebar.liquid
+++ b/snippets/product-page-horizontal-tabs-no-sidebar.liquid
@@ -754,6 +754,20 @@
                                     </div>
                                 </div>
                             {%- endif -%}
+                            {%- comment -%} Below gallery custom content blocks {%- endcomment -%}
+                            {%- for block in section.blocks -%}
+                              {%- if block.type == 'media_custom_liquid' -%}
+                                {%- liquid
+                                  assign spacing_top = block.settings.spacing_top
+                                  assign spacing_bottom = block.settings.spacing_bottom
+                                -%}
+                                <div class="productView-moreItem productView-moreItem--media{% if settings.banner_animation == 'effect_fade_up' %} scroll-trigger animate--slide-in{% endif %}"
+                                  style="--spacing-top: {{ spacing_top | append: 'px' }}; --spacing-bottom: {{ spacing_bottom | append: 'px' }}"
+                                >
+                                  {{ block.settings.custom_liquid }}
+                                </div>
+                              {%- endif -%}
+                            {%- endfor -%}
                         </div>
                     </div>
                     <div class="halo-productView-right productView-details clearfix">

--- a/snippets/product-page-left-right-sidebar.liquid
+++ b/snippets/product-page-left-right-sidebar.liquid
@@ -768,6 +768,20 @@
                                     </div>
                                 </div>
                             {%- endif -%}
+                            {%- comment -%} Below gallery custom content blocks {%- endcomment -%}
+                            {%- for block in section.blocks -%}
+                              {%- if block.type == 'media_custom_liquid' -%}
+                                {%- liquid
+                                  assign spacing_top = block.settings.spacing_top
+                                  assign spacing_bottom = block.settings.spacing_bottom
+                                -%}
+                                <div class="productView-moreItem productView-moreItem--media{% if settings.banner_animation == 'effect_fade_up' %} scroll-trigger animate--slide-in{% endif %}"
+                                  style="--spacing-top: {{ spacing_top | append: 'px' }}; --spacing-bottom: {{ spacing_bottom | append: 'px' }}"
+                                >
+                                  {{ block.settings.custom_liquid }}
+                                </div>
+                              {%- endif -%}
+                            {%- endfor -%}
                         </div>
                     </div>
                     <div class="halo-productView-right productView-details clearfix">

--- a/snippets/product-page-left-thumbs.liquid
+++ b/snippets/product-page-left-thumbs.liquid
@@ -758,6 +758,20 @@
                                     </div>
                                 </div>
                             {%- endif -%}
+                            {%- comment -%} Below gallery custom content blocks {%- endcomment -%}
+                            {%- for block in section.blocks -%}
+                              {%- if block.type == 'media_custom_liquid' -%}
+                                {%- liquid
+                                  assign spacing_top = block.settings.spacing_top
+                                  assign spacing_bottom = block.settings.spacing_bottom
+                                -%}
+                                <div class="productView-moreItem productView-moreItem--media{% if settings.banner_animation == 'effect_fade_up' %} scroll-trigger animate--slide-in{% endif %}"
+                                  style="--spacing-top: {{ spacing_top | append: 'px' }}; --spacing-bottom: {{ spacing_bottom | append: 'px' }}"
+                                >
+                                  {{ block.settings.custom_liquid }}
+                                </div>
+                              {%- endif -%}
+                            {%- endfor -%}
                         </div>
                     </div>
                     <div class="halo-productView-right productView-details clearfix">

--- a/snippets/product-page-right-thumbs.liquid
+++ b/snippets/product-page-right-thumbs.liquid
@@ -758,6 +758,20 @@
                                     </div>
                                 </div>
                             {%- endif -%}
+                            {%- comment -%} Below gallery custom content blocks {%- endcomment -%}
+                            {%- for block in section.blocks -%}
+                              {%- if block.type == 'media_custom_liquid' -%}
+                                {%- liquid
+                                  assign spacing_top = block.settings.spacing_top
+                                  assign spacing_bottom = block.settings.spacing_bottom
+                                -%}
+                                <div class="productView-moreItem productView-moreItem--media{% if settings.banner_animation == 'effect_fade_up' %} scroll-trigger animate--slide-in{% endif %}"
+                                  style="--spacing-top: {{ spacing_top | append: 'px' }}; --spacing-bottom: {{ spacing_bottom | append: 'px' }}"
+                                >
+                                  {{ block.settings.custom_liquid }}
+                                </div>
+                              {%- endif -%}
+                            {%- endfor -%}
                         </div>
                     </div>
                     <div class="halo-productView-right productView-details clearfix">

--- a/snippets/product-page.liquid
+++ b/snippets/product-page.liquid
@@ -796,6 +796,20 @@
                                     </div>
                                 </div>
                             {%- endif -%}
+                            {%- comment -%} Below gallery custom content blocks {%- endcomment -%}
+                            {%- for block in section.blocks -%}
+                              {%- if block.type == 'media_custom_liquid' -%}
+                                {%- liquid
+                                  assign spacing_top = block.settings.spacing_top
+                                  assign spacing_bottom = block.settings.spacing_bottom
+                                -%}
+                                <div class="productView-moreItem productView-moreItem--media{% if settings.banner_animation == 'effect_fade_up' %} scroll-trigger animate--slide-in{% endif %}"
+                                  style="--spacing-top: {{ spacing_top | append: 'px' }}; --spacing-bottom: {{ spacing_bottom | append: 'px' }}"
+                                >
+                                  {{ block.settings.custom_liquid }}
+                                </div>
+                              {%- endif -%}
+                            {%- endfor -%}
                         </div>
                     </div>
                     <div class="halo-productView-right productView-details clearfix">


### PR DESCRIPTION
This PR adds the new media_custom_liquid block below the PDP media gallery across all layouts.\n\n- Insert rendering loop under the gallery in all product-page snippets\n- Add media_custom_liquid schema block to all main-product sections\n- Uses block.settings.custom_liquid with per-block spacing\n- Optional animation classes based on settings.banner_animation\n- Keeps right-column custom_liquid blocks untouched\n\nNote: supersedes PR #7 (created from an incorrect base).