### PR TITLE
fix(pdp): shorten media_custom_liquid block name to <=25 chars

### DIFF
--- a/sections/main-product-full-width-2.liquid
+++ b/sections/main-product-full-width-2.liquid
@@ -3188,7 +3188,7 @@
         },
         {
             "type": "media_custom_liquid",
-            "name": "Custom liquid (below gallery)",
+            "name": "Custom liquid (media)",
             "settings": [
                 {
                     "type": "liquid",

--- a/sections/main-product-full-width.liquid
+++ b/sections/main-product-full-width.liquid
@@ -3192,7 +3192,7 @@
         },
         {
             "type": "media_custom_liquid",
-            "name": "Custom liquid (below gallery)",
+            "name": "Custom liquid (media)",
             "settings": [
                 {
                     "type": "liquid",

--- a/sections/main-product-gallery.liquid
+++ b/sections/main-product-gallery.liquid
@@ -3192,7 +3192,7 @@
         },
         {
             "type": "media_custom_liquid",
-            "name": "Custom liquid (below gallery)",
+            "name": "Custom liquid (media)",
             "settings": [
                 {
                     "type": "liquid",

--- a/sections/main-product-horizontal-tabs-no-sidebar.liquid
+++ b/sections/main-product-horizontal-tabs-no-sidebar.liquid
@@ -3167,7 +3167,7 @@
         },
         {
             "type": "media_custom_liquid",
-            "name": "Custom liquid (below gallery)",
+            "name": "Custom liquid (media)",
             "settings": [
                 {
                     "type": "liquid",

--- a/sections/main-product-left-right-sidebar.liquid
+++ b/sections/main-product-left-right-sidebar.liquid
@@ -3186,7 +3186,7 @@
         },
         {
             "type": "media_custom_liquid",
-            "name": "Custom liquid (below gallery)",
+            "name": "Custom liquid (media)",
             "settings": [
                 {
                     "type": "liquid",

--- a/sections/main-product-left-thumbs.liquid
+++ b/sections/main-product-left-thumbs.liquid
@@ -3186,7 +3186,7 @@
         },
         {
             "type": "media_custom_liquid",
-            "name": "Custom liquid (below gallery)",
+            "name": "Custom liquid (media)",
             "settings": [
                 {
                     "type": "liquid",

--- a/sections/main-product-right-thumbs.liquid
+++ b/sections/main-product-right-thumbs.liquid
@@ -3186,7 +3186,7 @@
         },
         {
             "type": "media_custom_liquid",
-            "name": "Custom liquid (below gallery)",
+            "name": "Custom liquid (media)",
             "settings": [
                 {
                     "type": "liquid",

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -3202,7 +3202,7 @@
         },
         {
             "type": "media_custom_liquid",
-            "name": "Custom liquid (below gallery)",
+            "name": "Custom liquid (media)",
             "settings": [
                 {
                     "type": "liquid",


### PR DESCRIPTION
Short Shopify schema fix.\n\n- Rename block display name to "Custom liquid (media)" across all product section schemas to satisfy the 25-char limit.\n- No functional changes to rendering loops.\n\nFollow-up to #8.