### PR TITLE
feat(product-specs): optional icon per attribute mapping

### DIFF
--- a/assets/product-specs.css
+++ b/assets/product-specs.css
@@ -1,0 +1,72 @@
+/* product-specs.css
+   Minimal styles for product specs snippet (grid + clamp)
+*/
+
+.product-specs { margin-top: 1rem; }
+
+.product-specs__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+@media (max-width: 768px) {
+  .product-specs__grid { grid-template-columns: 1fr; }
+}
+
+.product-specs__heading {
+  font-size: 1.125rem;
+  margin: 0 0 0.75rem;
+}
+
+.product-specs__desc-text {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: var(--clamp, 6);
+  line-clamp: var(--clamp, 6);
+}
+
+.product-specs__desc-text.is-expanded {
+  -webkit-line-clamp: unset;
+  line-clamp: unset;
+  display: block;
+}
+
+.product-specs__toggle {
+  margin-top: 0.5rem;
+  background: none;
+  border: 0;
+  color: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+}
+
+.product-specs__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.product-specs__item + .product-specs__item { margin-top: 0.5rem; }
+
+.product-specs__label {
+  font-size: 0.95rem;
+  margin: 0 0 0.125rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.product-specs__icon {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  flex: 0 0 auto;
+}
+
+.product-specs__value { font-size: 0.95rem; }
+
+.product-specs__chip { display: inline; }
+.product-specs__sep { opacity: 0.6; }

--- a/snippets/product-specs.liquid
+++ b/snippets/product-specs.liquid
@@ -1,0 +1,157 @@
+{%- comment -%}
+  Product specs snippet
+  - Renders product description with a robust "Ver más/Ver menos" toggle using CSS line clamp
+  - Renders a curated list of metafields automatically (no need to paste each shortcode)
+  - Usage: {% render 'product-specs', clamp_lines: 6 %}
+  - Override mapping (optional):
+    {% render 'product-specs', specs_override: "global.foo|Foo|text|fooicon, custom.bar|Bar|list|baricon" %}
+    Mapping format per item: namespace.key|Label|type|icon_class (icon_class is optional)
+{%- endcomment -%}
+
+{{ 'product-specs.css' | asset_url | stylesheet_tag }}
+
+{%- liquid
+  assign uid = section.id | default: product.id
+  assign clamp_lines = clamp_lines | default: 6
+
+  comment
+    Comma-separated mapping: namespace.key|Label|type
+    type: text | list (list will iterate metafield.value)
+  endcomment
+  assign specs_map = specs_override | default: "
+    global.materialshopi|Material|text,
+    global.tipodeplato|Tipo de plato|text,
+    global.tubelessshopi|Tubeless|text,
+    global.anchodelproductoshopi|Ancho del producto|text,
+    global.cantidad_de_huecos|Cantidad de huecos|text,
+    custom.marco|Marco|text,
+    global.tipo_de_frenoshopi|Tipo de Freno|text,
+    global.velocidades|Velocidades|text,
+    global.guantesldedo|Longitud Dedo|text,
+    global.generoshopi|Género|text,
+    global.espigo|Espigo|list,
+    global.desbloqueo|Desbloqueo|list,
+    global.consistenciashopi|Consistencia|text,
+    global.compatible_monitor_de_ritmo_cardiaco|Compatible Monitor Cardiaco|text,
+    global.color_del_lente|Color del Lente|text,
+    global.caracteristicas_del_material|Características del Material|text,
+    global.capacidadshopi|Capacidad|text,
+    custom.manillar|Manillar|text,
+    custom.tenedor|Tenedor|text,
+    custom.bater_a|Batería|text,
+    custom.cassette|Cassette|text,
+    custom.llantas|Llantas|text,
+    custom.suspensi_n|Suspensión|text,
+    global.tamano_de_rinshopi|Tamaño de Rin|text,
+    custom.motor|Motor|text,
+    custom.sensor|Sensor|text,
+    global.bluetooth|Bluetooth|text,
+    global.tensor|Tensor|text,
+    global.funciones_adicionalesshopi|Funciones adicionales|text,
+    global.cadencia|Cadencia|text
+  " | strip
+
+  assign specs_array = specs_map | split: ","
+  assign any_attr = false
+-%}
+
+{%- assign has_description = product.description != blank -%}
+{%- capture right_column -%}
+  <ul class="product-specs__list">
+  {%- for spec_str in specs_array -%}
+    {%- assign parts = spec_str | strip | split: "|" -%}
+    {%- assign ns_key = parts[0] | strip -%}
+    {%- assign label = parts[1] | strip -%}
+    {%- assign vtype = parts[2] | default: 'text' -%}
+    {%- assign icon_class = parts[3] | default: '' -%}
+    {%- assign ns = ns_key | split: "." | first -%}
+    {%- assign key = ns_key | split: "." | last -%}
+    {%- assign mf = product.metafields[ns][key] -%}
+
+    {%- if mf and mf != blank -%}
+      {%- assign any_attr = true -%}
+      <li class="product-specs__item">
+        <h4 class="product-specs__label">
+          {%- if icon_class != '' -%}
+            <span class="product-specs__icon {{ icon_class }}" aria-hidden="true"></span>
+          {%- endif -%}
+          <span class="product-specs__label-text">{{ label }}</span>
+        </h4>
+        <div class="product-specs__value">
+          {%- if vtype == 'list' and mf.value -%}
+            {%- for item in mf.value -%}
+              <span class="product-specs__chip">{{ item }}</span>{% unless forloop.last %}<span class="product-specs__sep">, </span>{% endunless %}
+            {%- endfor -%}
+          {%- else -%}
+            {{ mf | metafield_text }}
+          {%- endif -%}
+        </div>
+      </li>
+    {%- endif -%}
+  {%- endfor -%}
+  </ul>
+{%- endcapture -%}
+
+{%- if has_description or any_attr -%}
+<div class="product-specs" id="product-specs-{{ uid }}">
+  <div class="product-specs__grid">
+    {%- if has_description -%}
+      <div class="product-specs__col product-specs__col--desc">
+        <h3 class="product-specs__heading">Descripción</h3>
+        <div class="product-specs__desc" id="product-specs-desc-{{ uid }}">
+          <div class="product-specs__desc-text" style="--clamp: {{ clamp_lines }};">
+            {{ product.description }}
+          </div>
+          <button type="button" class="product-specs__toggle" aria-expanded="false" hidden>Ver más</button>
+        </div>
+      </div>
+    {%- endif -%}
+
+    {%- if any_attr -%}
+      <div class="product-specs__col product-specs__col--attrs">
+        <h3 class="product-specs__heading">Acerca del producto</h3>
+        {{ right_column }}
+      </div>
+    {%- endif -%}
+  </div>
+</div>
+
+<script>
+(function(){
+  var root = document.getElementById('product-specs-{{ uid }}');
+  if(!root) return;
+  var desc = root.querySelector('#product-specs-desc-{{ uid }} .product-specs__desc-text');
+  var btn  = root.querySelector('#product-specs-desc-{{ uid }} .product-specs__toggle');
+  if(!desc || !btn) return;
+
+  function updateToggleVisibility(){
+    // Show button only if clamped content overflows
+    var overflows = desc.scrollHeight - 1 > desc.clientHeight;
+    btn.hidden = !overflows;
+    // Reset text when not expanded
+    if(!overflows){
+      btn.setAttribute('aria-expanded','false');
+      btn.textContent = 'Ver más';
+      desc.classList.remove('is-expanded');
+    }
+  }
+
+  btn.addEventListener('click', function(){
+    var expanded = desc.classList.toggle('is-expanded');
+    btn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    btn.textContent = expanded ? 'Ver menos' : 'Ver más';
+  });
+
+  if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', updateToggleVisibility);
+  } else {
+    updateToggleVisibility();
+  }
+  window.addEventListener('load', updateToggleVisibility);
+  window.addEventListener('resize', function(){
+    clearTimeout(window.__ps_specs_rz);
+    window.__ps_specs_rz = setTimeout(updateToggleVisibility, 150);
+  });
+})();
+</script>
+{%- endif -%}


### PR DESCRIPTION
Adds product-specs snippet + CSS. Supports optional icon class per attribute via a 4th mapping parameter.

Usage:
- Basic: {% render 'product-specs', clamp_lines: 6 %}
- Override mapping (with icons): {% render 'product-specs', specs_override: "global.materialshopi|Material|text|generoicon, global.generoshopi|Género|text|marcaicon, global.bluetooth|Bluetooth|text|notas-corazonicon" %}

Also includes a robust “Ver más/Ver menos” toggle (line clamp) and button auto-hide when content doesn’t overflow.