### PR TITLE
fix(product-specs): avoid Liquid parsing error using capture default mapping

### DIFF
--- a/snippets/product-specs.liquid
+++ b/snippets/product-specs.liquid
@@ -18,7 +18,7 @@
     Comma-separated mapping: namespace.key|Label|type
     type: text | list (list will iterate metafield.value)
   endcomment
-  assign specs_map = specs_override | default: "
+  capture specs_map_default
     global.materialshopi|Material|text,
     global.tipodeplato|Tipo de plato|text,
     global.tubelessshopi|Tubeless|text,
@@ -49,7 +49,9 @@
     global.tensor|Tensor|text,
     global.funciones_adicionalesshopi|Funciones adicionales|text,
     global.cadencia|Cadencia|text
-  " | strip
+  endcapture
+
+  assign specs_map = specs_override | default: specs_map_default | strip
 
   assign specs_array = specs_map | split: ","
   assign any_attr = false


### PR DESCRIPTION
Follow-up fix: the initial PR merged before a small Liquid parsing fix landed.\n\n- Define default mapping via capture to avoid "Unknown tag 'global'"\n- No functional changes to rendering or CSS\n\nPlease merge to ensure theme validation passes consistently.