### PR TITLE
docs(changelog): product-specs updates (fix + styling + icons)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this repository will be documented in this file.
 
+## 2025-09-19 17:16 (-05:00)
+
+- Product Specs snippet (PDP)
+  - Fix: define default metafield mapping via `capture` to avoid Liquid parsing error (Unknown tag 'global').
+  - Style: align visuals with Financing card (bordered white card, rounded corners, padded grid, stronger headings, subtle dividers).
+  - Feature: support optional 4th mapping parameter `icon_class` to render an icon before each label.
+
 ## 2025-08-29 11:12 (-05:00)
 
 Initial Guided Finder integration and configuration scaffolding.


### PR DESCRIPTION
Adds a changelog entry summarizing the latest product-specs changes already merged to main (PRs #10 and #11):\n- Liquid fix using capture for default mapping (avoids Unknown tag 'global')\n- Visual alignment with financing card (bordered white card, padding, headings, dividers)\n- Optional icon_class (4th mapping param) support in snippet\n\nThis PR is for tracking/documentation and to provide a fresh PR endpoint as requested.